### PR TITLE
Fix detecttool import in pydarknet_helpers.py

### DIFF
--- a/pydarknet/pydarknet_helpers.py
+++ b/pydarknet/pydarknet_helpers.py
@@ -6,7 +6,7 @@ from os.path import join, realpath, dirname
 import numpy as np
 import ctypes as C
 import sys
-import detecttools.ctypes_interface as ctypes_interface
+import ibeis.detecttools.ctypes_interface as ctypes_interface
 
 
 def ensure_bytes_strings(str_list):


### PR DESCRIPTION
detecttool was a separate package but has been moved into ibeis.  The
imports need to be changed from `import detecttool` to
`import ibeis.detecttool`.