### PR TITLE
Add and run pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,15 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
+
+  - repo: local
+    hooks:
+      - id: brunette
+        name: brunette
+        description: Run Brunette on Python code (fork of Black).
+        entry: brunette --config=setup.cfg
+        language: system
+        types: [python]
   - repo: https://github.com/psf/black
     rev: stable
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,15 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 
+  - repo: https://github.com/iconmaster5326/cmake-format-pre-commit-hook
+    rev: master
+    hooks:
+      - id: cmake-format
+        exclude: >
+          (?x)^(
+              .*.cmake.in
+          )$
+
   - repo: local
     hooks:
       - id: brunette

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.13.0)
-set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
 
 if(COMMAND cmake_policy)
-    cmake_policy(SET CMP0003 NEW)
-    cmake_policy(SET CMP0042 NEW)
+  cmake_policy(SET CMP0003 NEW)
+  cmake_policy(SET CMP0042 NEW)
 endif(COMMAND cmake_policy)
 
 project(pydarknet LANGUAGES C CXX)
@@ -16,8 +16,7 @@ function(_pycmd outvar cmd)
     COMMAND python -c "${cmd}"
     RESULT_VARIABLE _exitcode
     OUTPUT_VARIABLE _output
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   if(NOT ${_exitcode} EQUAL 0)
     message(ERROR "Failed when running python code: \"\"\"
 ${cmd}\"\"\"")
@@ -25,68 +24,70 @@ ${cmd}\"\"\"")
   endif()
   # Remove supurflous newlines (artifacts of print)
   string(STRIP "${_output}" _output)
-  set(${outvar} "${_output}" PARENT_SCOPE)
+  set(${outvar}
+      "${_output}"
+      PARENT_SCOPE)
 endfunction()
 _pycmd(PYDARKNET_VERSION "import setup; print(setup.VERSION)")
 
 message(STATUS "PYDARKNET_VERSION = ${PYDARKNET_VERSION}")
 
-DISSECT_VERSION()
-GET_OS_INFO()
+dissect_version()
+get_os_info()
 
-if (OS_IS_MACOS)
-    message(STATUS "INCLUDING MACPORTS")
+if(OS_IS_MACOS)
+  message(STATUS "INCLUDING MACPORTS")
 
-    include_directories(/opt/local/include)
-    link_directories(/opt/local/lib)
+  include_directories(/opt/local/include)
+  link_directories(/opt/local/lib)
 
-    set(CMAKE_INSTALL_RPATH "/opt/local/lib")
+  set(CMAKE_INSTALL_RPATH "/opt/local/lib")
 
-    # Add flags to support clang2
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -stdlib=libc++")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++")
+  # Add flags to support clang2
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -stdlib=libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lc++")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lc++")
 endif()
 
-# Setup basic python stuff and ensure we have skbuild
-#list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/CMake")
-#include( skbuild-helpers )
+# Setup basic python stuff and ensure we have skbuild list(INSERT
+# CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/CMake") include( skbuild-helpers )
 
-#######################################
+# ##############################################################################
 
 # detect if using the Clang compiler
 if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANG 1)
-endif ()
+endif()
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANGXX 1)
-endif ()
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # Add an "uninstall" target
-CONFIGURE_FILE ("${PROJECT_SOURCE_DIR}/cmake/uninstall_target.cmake.in"
-    "${PROJECT_BINARY_DIR}/uninstall_target.cmake" IMMEDIATE @ONLY)
-ADD_CUSTOM_TARGET (uninstall "${CMAKE_COMMAND}" -P
-    "${PROJECT_BINARY_DIR}/uninstall_target.cmake")
+configure_file("${PROJECT_SOURCE_DIR}/cmake/uninstall_target.cmake.in"
+               "${PROJECT_BINARY_DIR}/uninstall_target.cmake" IMMEDIATE @ONLY)
+add_custom_target(uninstall "${CMAKE_COMMAND}" -P
+                            "${PROJECT_BINARY_DIR}/uninstall_target.cmake")
 
-# Set the build type.  Options are:
-#  Debug          : w/ debug symbols, w/o optimization
-#  Release        : w/o debug symbols, w/ optimization
-#  RelWithDebInfo : w/ debug symbols, w/ optimization
-#  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
+# Set the build type.  Options are: Debug          : w/ debug symbols, w/o
+# optimization Release        : w/o debug symbols, w/ optimization
+# RelWithDebInfo : w/ debug symbols, w/ optimization MinSizeRel     : w/o debug
+# symbols, w/ optimization, stripped binaries
 
-if (NOT CMAKE_BUILD_TYPE)
-    #set(CMAKE_BUILD_TYPE Release)
-    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type" FORCE)
-    #set(CMAKE_BUILD_TYPE Debug)
+if(NOT CMAKE_BUILD_TYPE)
+  # set(CMAKE_BUILD_TYPE Release)
+  set(CMAKE_BUILD_TYPE
+      RelWithDebInfo
+      CACHE STRING "Build type" FORCE)
+  # set(CMAKE_BUILD_TYPE Debug)
 endif()
 
-#set the default path for built executables to the "bin" directory
+# set the default path for built executables to the "bin" directory
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-#set the default path for built libraries to the "lib" directory
+# set the default path for built libraries to the "lib" directory
 set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
 # set output path for tests
 set(TEST_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/test)
@@ -96,49 +97,56 @@ option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_DOC "Build documentation" ON)
 
-set(NVCC_COMPILER_BINDIR "" CACHE PATH  "Directory where nvcc should look for C++ compiler. This is passed to nvcc through the --compiler-bindir option.")
+set(NVCC_COMPILER_BINDIR
+    ""
+    CACHE
+      PATH
+      "Directory where nvcc should look for C++ compiler. This is passed to nvcc through the --compiler-bindir option."
+)
 
-find_package( OpenCV REQUIRED )
-IF(OpenCV_FOUND)
+find_package(OpenCV REQUIRED)
+if(OpenCV_FOUND)
   add_definitions(-DOPENCV)
   include_directories(${OpenCV_INCLUDE_DIR})
-ELSE()
+else()
   message(FATAL_ERROR "OpenCV NOT found")
-ENDIF()
+endif()
 
-find_package( Threads REQUIRED )
-IF(Threads_FOUND)
+find_package(Threads REQUIRED)
+if(Threads_FOUND)
   message(STATUS "Threads found")
-ELSE()
+else()
   message(FATAL_ERROR "Threads NOT found")
-ENDIF()
+endif()
 
 # CUDA support
-if (BUILD_CUDA_LIB)
-    find_package(CUDA)
-    if (CUDA_FOUND)
-        enable_language(CUDA)
-        add_definitions(-DGPU)
-        message(STATUS "CUDA found (include: ${CUDA_INCLUDE_DIRS}, lib: ${CUDA_LIBRARIES})")
-        include_directories(${CUDA_INCLUDE_DIRS})
-    else(CUDA_FOUND)
-        message(STATUS "CUDA not found, CUDA library will not be built")
-        set(BUILD_CUDA_LIB OFF)
-    endif(CUDA_FOUND)
+if(BUILD_CUDA_LIB)
+  find_package(CUDA)
+  if(CUDA_FOUND)
+    enable_language(CUDA)
+    add_definitions(-DGPU)
+    message(
+      STATUS
+        "CUDA found (include: ${CUDA_INCLUDE_DIRS}, lib: ${CUDA_LIBRARIES})")
+    include_directories(${CUDA_INCLUDE_DIRS})
+  else(CUDA_FOUND)
+    message(STATUS "CUDA not found, CUDA library will not be built")
+    set(BUILD_CUDA_LIB OFF)
+  endif(CUDA_FOUND)
 endif(BUILD_CUDA_LIB)
 
 find_package(PkgConfig REQUIRED)
 
-#set the C/C++ include path to the "include" directory
+# set the C/C++ include path to the "include" directory
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/src/cpp)
 
-# require proper c++
-#add_definitions( "-Wall -ansi -pedantic" )
+# require proper c++ add_definitions( "-Wall -ansi -pedantic" )
 if(CMAKE_C_COMPILER_ID MATCHES "MSVC" OR CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-    # lots of warnings with cl.exe right now, use /W1
-    add_definitions("/W1 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS /bigobj")
+  # lots of warnings with cl.exe right now, use /W1
+  add_definitions(
+    "/W1 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS /bigobj")
 else()
-    add_definitions("-Wall -O2 -Wno-unknown-pragmas -Wno-unused-function")
+  add_definitions("-Wall -O2 -Wno-unknown-pragmas -Wno-unused-function")
 endif()
 
 # install and export variables
@@ -149,62 +157,50 @@ set(project_config "${generated_dir}/pydarknet-config.cmake")
 set(targets_export_name "pydarknet-targets")
 set(namespace "pydarknet::")
 
-if (SKBUILD)
+if(SKBUILD)
   # Override output paths when using scikit-build
   set(PYDARKNET_LIB_INSTALL_DIR "pydarknet/lib")
   set(PYDARKNET_INCLUDE_INSTALL_DIR "pydarknet/include")
 endif()
 
-if (NOT SKBUILD)
-  add_subdirectory( CMake )
+if(NOT SKBUILD)
+  add_subdirectory(CMake)
 endif()
-add_subdirectory( src )
-if (BUILD_EXAMPLES)
-  add_subdirectory( examples )
+add_subdirectory(src)
+if(BUILD_EXAMPLES)
+  add_subdirectory(examples)
 endif(BUILD_EXAMPLES)
-if (BUILD_TESTS)
-  add_subdirectory( test )
-endif (BUILD_TESTS)
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif(BUILD_TESTS)
 
-# CMake configuration file creation
-# Include module with fuction 'write_basic_package_version_file'
+# CMake configuration file creation Include module with fuction
+# 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)
 
-# Configure 'pydarknet-config-version.cmake'
-# Note: PYDARKNET_VERSION is used as a VERSION
+# Configure 'pydarknet-config-version.cmake' Note: PYDARKNET_VERSION is used as
+# a VERSION
 write_basic_package_version_file(
-    "${version_config}"
-    VERSION ${PYDARKNET_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
+  "${version_config}"
+  VERSION ${PYDARKNET_VERSION}
+  COMPATIBILITY SameMajorVersion)
 
-# Configure 'pydarknet-config.cmake'
-# Use variables:
-#   * targets_export_name
-#   * PROJECT_NAME
-configure_package_config_file(
-  "cmake/Config.cmake.in"
-    "${project_config}"
-    INSTALL_DESTINATION "${config_install_dir}"
-)
+# Configure 'pydarknet-config.cmake' Use variables: * targets_export_name *
+# PROJECT_NAME
+configure_package_config_file("cmake/Config.cmake.in" "${project_config}"
+                              INSTALL_DESTINATION "${config_install_dir}")
 
-if (NOT SKBUILD)
-  # Config
-  #   * <prefix>/lib/cmake/pydarknet/pydarknet-config.cmake
-  #   * <prefix>/lib/cmake/pydarknet/pydarknet-config-version.cmake
+if(NOT SKBUILD)
+  # Config * <prefix>/lib/cmake/pydarknet/pydarknet-config.cmake *
+  # <prefix>/lib/cmake/pydarknet/pydarknet-config-version.cmake
+  install(FILES "${project_config}" "${version_config}"
+          DESTINATION "${config_install_dir}")
+  # Config * <prefix>/lib/cmake/pydarknet/pydarknet-targets.cmake
   install(
-      FILES "${project_config}" "${version_config}"
-      DESTINATION "${config_install_dir}"
-  )
-  # Config
-  #   * <prefix>/lib/cmake/pydarknet/pydarknet-targets.cmake
-  install(
-      EXPORT "${targets_export_name}"
-      NAMESPACE "${namespace}"
-      DESTINATION "${config_install_dir}"
-  )
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}")
 endif()
-
 
 # CPACK options
 
@@ -225,7 +221,7 @@ if(EXISTS ${NSIS_PROGRAM})
 endif(EXISTS ${NSIS_PROGRAM})
 # dpkg
 find_program(PACKAGE_MAKER_PROGRAM PackageMaker
-      HINTS /Developer/Applications/Utilities)
+             HINTS /Developer/Applications/Utilities)
 if(EXISTS ${PACKAGE_MAKER_PROGRAM})
   list(APPEND CPACK_GENERATOR "PackageMaker")
 endif(EXISTS ${PACKAGE_MAKER_PROGRAM})
@@ -236,12 +232,11 @@ set(CPACK_SET_DESTDIR ON)
 include(InstallRequiredSystemLibraries)
 set(CPACK_PACKAGE_CONTACT "Marius Muja")
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-SET(CPACK_PACKAGE_VERSION ${PYDARKNET_VERSION})
-SET(CPACK_PACKAGE_VERSION_MAJOR ${PYDARKNET_VERSION_MAJOR})
-SET(CPACK_PACKAGE_VERSION_MINOR ${PYDARKNET_VERSION_MINOR})
-SET(CPACK_PACKAGE_VERSION_PATCH ${PYDARKNET_VERSION_PATCH})
+set(CPACK_PACKAGE_VERSION ${PYDARKNET_VERSION})
+set(CPACK_PACKAGE_VERSION_MAJOR ${PYDARKNET_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${PYDARKNET_VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${PYDARKNET_VERSION_PATCH})
 include(CPack)
-
 
 message(STATUS "Install prefix: ${CMAKE_INSTALL_PREFIX}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/_graveyard/data/labels/make_labels.py
+++ b/_graveyard/data/labels/make_labels.py
@@ -111,6 +111,6 @@ labels = [
 
 for word in labels:
     os.system(
-        "convert -fill black -background white -bordercolor white -border 4 -font futura-normal -pointsize 18 label:\"%s\" \"%s.png\""
+        'convert -fill black -background white -bordercolor white -border 4 -font futura-normal -pointsize 18 label:"%s" "%s.png"'
         % (word, word)
     )

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(PKG_DESC "Image Tools for Wildbook IA")
 set(pkg_conf_file ${CMAKE_CURRENT_BINARY_DIR}/pydarknet.pc)
 configure_file(pydarknet.pc.in ${pkg_conf_file} @ONLY)
-install(FILES ${pkg_conf_file}
-    DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}/pkgconfig/ COMPONENT pkgconfig)
+install(
+  FILES ${pkg_conf_file}
+  DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}/pkgconfig/
+  COMPONENT pkgconfig)

--- a/cmake/FindPyDarknet.cmake
+++ b/cmake/FindPyDarknet.cmake
@@ -1,10 +1,9 @@
-###############################################################################
+# ##############################################################################
 # Find PyDarknet
 #
-# This sets the following variables:
-# PYDARKNET_FOUND - True if pydarknet was found.
-# PYDARKNET_INCLUDE_DIRS - Directories containing the pydarknet include files.
-# PYDARKNET_LIBRARIES - Libraries needed to use pydarknet.
+# This sets the following variables: PYDARKNET_FOUND - True if pydarknet was
+# found. PYDARKNET_INCLUDE_DIRS - Directories containing the pydarknet include
+# files. PYDARKNET_LIBRARIES - Libraries needed to use pydarknet.
 # PYDARKNET_DEFINITIONS - Compiler flags for pydarknet.
 
 find_package(PkgConfig)
@@ -12,16 +11,16 @@ pkg_check_modules(PC_PYDARKNET pydarknet)
 set(PYDARKNET_DEFINITIONS ${PC_PYDARKNET_CFLAGS_OTHER})
 
 find_path(PYDARKNET_INCLUDE_DIR pydarknet/pydarknet.hpp
-    HINTS ${PC_PYDARKNET_INCLUDEDIR} ${PC_PYDARKNET_INCLUDE_DIRS})
+          HINTS ${PC_PYDARKNET_INCLUDEDIR} ${PC_PYDARKNET_INCLUDE_DIRS})
 
-find_library(PYDARKNET_LIBRARY pydarknet
-    HINTS ${PC_PYDARKNET_LIBDIR} ${PC_PYDARKNET_LIBRARY_DIRS})
+find_library(PYDARKNET_LIBRARY pydarknet HINTS ${PC_PYDARKNET_LIBDIR}
+                                               ${PC_PYDARKNET_LIBRARY_DIRS})
 
 set(PYDARKNET_INCLUDE_DIRS ${PYDARKNET_INCLUDE_DIR})
 set(PYDARKNET_LIBRARIES ${PYDARKNET_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(PyDarknet DEFAULT_MSG
-    PYDARKNET_LIBRARY PYDARKNET_INCLUDE_DIR)
+find_package_handle_standard_args(PyDarknet DEFAULT_MSG PYDARKNET_LIBRARY
+                                  PYDARKNET_INCLUDE_DIR)
 
 mark_as_advanced(PYDARKNET_LIBRARY PYDARKNET_INCLUDE_DIR)

--- a/cmake/pydarknet_utils.cmake
+++ b/cmake/pydarknet_utils.cmake
@@ -1,45 +1,47 @@
 macro(GET_OS_INFO)
-    string(REGEX MATCH "Linux" OS_IS_LINUX ${CMAKE_SYSTEM_NAME})
-    string(REGEX MATCH "Darwin" OS_IS_MACOS ${CMAKE_SYSTEM_NAME})
-    set(PYDARKNET_LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
-    set(PYDARKNET_INCLUDE_INSTALL_DIR
-        "include/${PROJECT_NAME_LOWER}-${PYDARKNET_VERSION_MAJOR}.${PYDARKNET_VERSION_MINOR}")
+  string(REGEX MATCH "Linux" OS_IS_LINUX ${CMAKE_SYSTEM_NAME})
+  string(REGEX MATCH "Darwin" OS_IS_MACOS ${CMAKE_SYSTEM_NAME})
+  set(PYDARKNET_LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
+  set(PYDARKNET_INCLUDE_INSTALL_DIR
+      "include/${PROJECT_NAME_LOWER}-${PYDARKNET_VERSION_MAJOR}.${PYDARKNET_VERSION_MINOR}"
+  )
 endmacro(GET_OS_INFO)
 
-
 macro(DISSECT_VERSION)
-    # Find version components
-    message(STATUS "PYDARKNET_VERSION = ${PYDARKNET_VERSION}")
-    string(REGEX REPLACE "^([0-9]+).*" "\\1"
-        PYDARKNET_VERSION_MAJOR "${PYDARKNET_VERSION}")
-    string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1"
-        PYDARKNET_VERSION_MINOR "${PYDARKNET_VERSION}")
-    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1"
-        PYDARKNET_VERSION_PATCH ${PYDARKNET_VERSION})
-    string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.[0-9]+(.*)" "\\1"
-        PYDARKNET_VERSION_CANDIDATE ${PYDARKNET_VERSION})
-    set(PYDARKNET_SOVERSION "${PYDARKNET_VERSION_MAJOR}.${PYDARKNET_VERSION_MINOR}")
-    message(STATUS "PYDARKNET_SOVERSION = ${PYDARKNET_SOVERSION}")
+  # Find version components
+  message(STATUS "PYDARKNET_VERSION = ${PYDARKNET_VERSION}")
+  string(REGEX REPLACE "^([0-9]+).*" "\\1" PYDARKNET_VERSION_MAJOR
+                       "${PYDARKNET_VERSION}")
+  string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" PYDARKNET_VERSION_MINOR
+                       "${PYDARKNET_VERSION}")
+  string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+)" "\\1"
+                       PYDARKNET_VERSION_PATCH ${PYDARKNET_VERSION})
+  string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.[0-9]+(.*)" "\\1"
+                       PYDARKNET_VERSION_CANDIDATE ${PYDARKNET_VERSION})
+  set(PYDARKNET_SOVERSION
+      "${PYDARKNET_VERSION_MAJOR}.${PYDARKNET_VERSION_MINOR}")
+  message(STATUS "PYDARKNET_SOVERSION = ${PYDARKNET_SOVERSION}")
 endmacro(DISSECT_VERSION)
 
-
 macro(pydarknet_add_pyunit file)
-    # find test file
-    set(_file_name _file_name-NOTFOUND)
-    find_file(_file_name ${file} ${CMAKE_CURRENT_SOURCE_DIR})
-    if(NOT _file_name)
-        message(FATAL_ERROR "Can't find pyunit file \"${file}\"")
-    endif(NOT _file_name)
+  # find test file
+  set(_file_name _file_name-NOTFOUND)
+  find_file(_file_name ${file} ${CMAKE_CURRENT_SOURCE_DIR})
+  if(NOT _file_name)
+    message(FATAL_ERROR "Can't find pyunit file \"${file}\"")
+  endif(NOT _file_name)
 
-    # add target for running test
-    string(REPLACE "/" "_" _testname ${file})
-    add_custom_target(pyunit_${_testname}
-                    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/bin/run_test.py ${_file_name}
-                    DEPENDS ${_file_name}
-                    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
-                    VERBATIM
-                    COMMENT "Running pyunit test(s) ${file}" )
-    # add dependency to 'test' target
-    add_dependencies(pyunit_${_testname} pydarknet)
-    add_dependencies(test pyunit_${_testname})
+  # add target for running test
+  string(REPLACE "/" "_" _testname ${file})
+  add_custom_target(
+    pyunit_${_testname}
+    COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/bin/run_test.py
+            ${_file_name}
+    DEPENDS ${_file_name}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
+    VERBATIM
+    COMMENT "Running pyunit test(s) ${file}")
+  # add dependency to 'test' target
+  add_dependencies(pyunit_${_testname} pydarknet)
+  add_dependencies(test pyunit_${_testname})
 endmacro(pydarknet_add_pyunit)

--- a/cmake/python_utils.cmake
+++ b/cmake/python_utils.cmake
@@ -1,51 +1,42 @@
-###
+#
 # Finds the python binaries, libs, include, and site-packages paths
 #
 # The purpose of this file is to export variables that will be used in
-# kwiver/CMake/utils/kwiver-utils-python.cmake and
-# kwiver/sprokit/conf/sprokit-macro-python.cmake (the latter will eventually be
-# consolidated into the former)
+# kwiver/CMake/utils/kwiver-utils-python.cmake and kwiver/sprokit/conf/sprokit-
+# macro-python.cmake (the latter will eventually be consolidated into the
+# former)
 #
 # User options defined in this file:
 #
-#    MAJOR_PYTHON_VERSION
-#      The major python version to target (either 2 or 3)
-#
+# MAJOR_PYTHON_VERSION The major python version to target (either 2 or 3)
 #
 # Calls find_packages to on python interpreter/libraries which defines:
 #
-#    PYTHON_EXECUTABLE
-#    PYTHON_INCLUDE_DIR
-#    PYTHON_LIBRARY
-#    PYTHON_LIBRARY_DEBUG
+# PYTHON_EXECUTABLE PYTHON_INCLUDE_DIR PYTHON_LIBRARY PYTHON_LIBRARY_DEBUG
 #
 # Exported variables used by python utility functions are:
 #
-#    PYTHON_VERSION
-#      the major/minor python version
+# PYTHON_VERSION the major/minor python version
 #
-#    PYTHON_ABI_FLAGS
-#      Python abstract binary interface flags (used internally for defining
-#      subsequent variables, but settable by the user as an advanced setting)
+# PYTHON_ABI_FLAGS Python abstract binary interface flags (used internally for
+# defining subsequent variables, but settable by the user as an advanced
+# setting)
 #
-#    python_site_packages
-#      Location where python packages are installed relative to your python
-#      install directory. For example:
-#        Windows system install: Lib\site-packages
-#        Debian system install: lib/python2.7/dist-packages
-#        Debian virtualenv install: lib/python3.5/site-packages
+# python_site_packages Location where python packages are installed relative to
+# your python install directory. For example: Windows system install: Lib\site-
+# packages Debian system install: lib/python2.7/dist-packages Debian virtualenv
+# install: lib/python3.5/site-packages
 #
-#    python_sitename
-#      The basename of the python_site_packages directory. This is either
-#      site-packages (in most cases) or dist-packages (if your python was
-#      configured by a debian package manager). If you are using a python
-#      virtualenv (you should be) then this will be site-packages
+# python_sitename The basename of the python_site_packages directory. This is
+# either site-packages (in most cases) or dist-packages (if your python was
+# configured by a debian package manager). If you are using a python virtualenv
+# (you should be) then this will be site-packages
 
-###
+#
 # Private helper function to execute `python -c "<cmd>"`
 #
-# Runs a python command and populates an outvar with the result of stdout.
-# Be careful of indentation if `cmd` is multiline.
+# Runs a python command and populates an outvar with the result of stdout. Be
+# careful of indentation if `cmd` is multiline.
 #
 function(_pycmd outvar cmd)
   execute_process(
@@ -60,38 +51,40 @@ ${cmd}\"\"\"")
   endif()
   # Remove supurflous newlines (artifacts of print)
   string(STRIP "${_output}" _output)
-  set(${outvar} "${_output}" PARENT_SCOPE)
+  set(${outvar}
+      "${_output}"
+      PARENT_SCOPE)
 endfunction()
 
-
-###
+#
 # Python major version user option
 #
 
 # Respect the PYTHON_VERSION_MAJOR version if it is set
-if (PYTHON_VERSION_MAJOR)
+if(PYTHON_VERSION_MAJOR)
   set(DEFAULT_PYTHON_MAJOR ${PYTHON_VERSION_MAJOR})
 else()
   set(DEFAULT_PYTHON_MAJOR "3")
 endif()
 
-
-set(MAJOR_PYTHON_VERSION "${DEFAULT_PYTHON_MAJOR}" CACHE STRING "Python version to use: 3 or 2")
+set(MAJOR_PYTHON_VERSION
+    "${DEFAULT_PYTHON_MAJOR}"
+    CACHE STRING "Python version to use: 3 or 2")
 set_property(CACHE MAJOR_PYTHON_VERSION PROPERTY STRINGS "3" "2")
 
-
-###
+#
 # Detect major version change (part1)
 #
-# Clear cached variables when the user changes major python versions.
-# When this happens, we need to re-find the bin, include, and libs
+# Clear cached variables when the user changes major python versions. When this
+# happens, we need to re-find the bin, include, and libs
 #
-if (NOT __prev_kwiver_pyversion STREQUAL MAJOR_PYTHON_VERSION)
+if(NOT __prev_kwiver_pyversion STREQUAL MAJOR_PYTHON_VERSION)
   # but dont clobber initial settings in the instance they are specified via
   # commandline (e.g  cmake -DPYTHON_EXECUTABLE=/my/special/python)
-  if (__prev_kwiver_pyversion)
+  if(__prev_kwiver_pyversion)
     message(STATUS "The Python version changed; refinding the interpreter")
-    message(STATUS "The previous Python version was: \"${__prev_kwiver_pyversion}\"")
+    message(
+      STATUS "The previous Python version was: \"${__prev_kwiver_pyversion}\"")
     unset(__prev_kwiver_pyversion CACHE)
     unset(PYTHON_EXECUTABLE CACHE)
     unset(PYTHON_INCLUDE_DIR CACHE)
@@ -101,18 +94,17 @@ if (NOT __prev_kwiver_pyversion STREQUAL MAJOR_PYTHON_VERSION)
   endif()
 endif()
 
-
-###
 #
 # Mark the previous version so we can determine when python versions change
 #
-set(__prev_kwiver_pyversion "${MAJOR_PYTHON_VERSION}" CACHE INTERNAL
-  "allows us to determine if the user changes python version")
+set(__prev_kwiver_pyversion
+    "${MAJOR_PYTHON_VERSION}"
+    CACHE INTERNAL "allows us to determine if the user changes python version")
 
-###
+#
 # Python interpreter and libraries
 #
-if (MAJOR_PYTHON_VERSION STREQUAL "3")
+if(MAJOR_PYTHON_VERSION STREQUAL "3")
   # note, 3.4 is a minimum version
   find_package(PythonInterp 3.4 REQUIRED)
   find_package(PythonLibs 3.4 REQUIRED)
@@ -122,58 +114,64 @@ else()
 endif()
 include_directories(SYSTEM ${PYTHON_INCLUDE_DIR})
 
-
-###
+#
 # Python site-packages
 #
 # Get canonical directory for python site packages (relative to install
 # location).  It varys from system to system.
 #
-_pycmd(python_site_packages "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))")
+_pycmd(
+  python_site_packages
+  "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix=''))")
 message(STATUS "python_site_packages = ${python_site_packages}")
-# Current usage determines most of the path in alternate ways.
-# All we need to supply is the '*-packages' directory name.
-# Customers could be converted to accept a larger part of the path from this function.
+# Current usage determines most of the path in alternate ways. All we need to
+# supply is the '*-packages' directory name. Customers could be converted to
+# accept a larger part of the path from this function.
 get_filename_component(python_sitename ${python_site_packages} NAME)
 
-
-###
+#
 # Python major/minor version
 #
-# Use the executable to find the major/minor version.
-# If you want to change this, then change the executable.
+# Use the executable to find the major/minor version. If you want to change
+# this, then change the executable.
 #
 _pycmd(PYTHON_VERSION "import sys; print(sys.version[0:3])")
 # assert that the right python version was found
 if(NOT PYTHON_VERSION MATCHES "^${MAJOR_PYTHON_VERSION}.*")
   message(STATUS "MAJOR_PYTHON_VERSION = ${MAJOR_PYTHON_VERSION}")
   message(STATUS "PYTHON_VERSION = ${PYTHON_VERSION}")
-  message(FATAL_ERROR "Requested python \"${MAJOR_PYTHON_VERSION}\" but got \"${PYTHON_VERSION}\"")
+  message(
+    FATAL_ERROR
+      "Requested python \"${MAJOR_PYTHON_VERSION}\" but got \"${PYTHON_VERSION}\""
+  )
 endif()
 
-
-###
+#
 # Python ABI Flags
 #
 # See PEP 3149 - ABI (application binary interface) version tagged .so files
 # https://www.python.org/dev/peps/pep-3149/
 #
-if (MAJOR_PYTHON_VERSION STREQUAL "3")
+if(MAJOR_PYTHON_VERSION STREQUAL "3")
   # In python 3, we can determine what the ABI flags are
-  _pycmd(_python_abi_flags "from distutils import sysconfig; print(sysconfig.get_config_var('ABIFLAGS'))")
+  _pycmd(
+    _python_abi_flags
+    "from distutils import sysconfig; print(sysconfig.get_config_var('ABIFLAGS'))"
+  )
 else()
   # Not sure if ABI flags are easilly found (or are even used in python2)
   set(_python_abi_flags, "")
 endif()
-set(PYTHON_ABIFLAGS "${_python_abi_flags}"
-  CACHE STRING "The ABI flags for the version of Python being used")
+set(PYTHON_ABIFLAGS
+    "${_python_abi_flags}"
+    CACHE STRING "The ABI flags for the version of Python being used")
 mark_as_advanced(PYTHON_ABIFLAGS)
 
-
-###
+#
 # Status string for debugging
 #
-set(PYTHON_CONFIG_STATUS "
+set(PYTHON_CONFIG_STATUS
+    "
 PYTHON_CONFIG_STATUS
   * PYTHON_EXECUTABLE = \"${PYTHON_EXECUTABLE}\"
   * PYTHON_INCLUDE_DIR = \"${PYTHON_INCLUDE_DIR}\"

--- a/cmake/python_utils.cmake
+++ b/cmake/python_utils.cmake
@@ -52,7 +52,7 @@ function(_pycmd outvar cmd)
     COMMAND "${PYTHON_EXECUTABLE}" -c "${cmd}"
     RESULT_VARIABLE _exitcode
     OUTPUT_VARIABLE _output
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   if(NOT ${_exitcode} EQUAL 0)
     message(ERROR "Failed when running python code: \"\"\"
 ${cmd}\"\"\"")

--- a/pydarknet/pydarknet_helpers.py
+++ b/pydarknet/pydarknet_helpers.py
@@ -89,7 +89,7 @@ def _find_c_shared_library_by_device(device='cpu'):
 
 
 def _load_c_shared_library(METHODS, device='cpu'):
-    ''' Loads the pydarknet dynamic library and defines its functions '''
+    """ Loads the pydarknet dynamic library and defines its functions """
 
     darknet_clib, def_cfunc = _find_c_shared_library_by_device(device=device)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,3 +66,9 @@ ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E
 
 # Exclude the git directory and virtualenv directory (as `.env`)
 exclude = .git,.env
+
+[tool:brunette]
+line-length = 90
+verbose = false
+# skip-string-normalization = true
+single-quotes = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 # This section configures `flake8`, the python linting utility.
 # See also https://flake8.pycqa.org/en/latest/user/configuration.html
-ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E203,E221,E222,E241,E265,E271,E272,E301,E501,N802,N803,N805,N806,W503
+ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E203,E221,E222,E231,E241,E265,E271,E272,E301,E501,N802,N803,N805,N806,W503
 # D100 - Missing docstring in public module
 # D101 - Missing docstring in public class
 # D102 - Missing docstring in public method
@@ -22,6 +22,7 @@ ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E
 # E203 - whitespace before ‘:’
 # E221 - multiple spaces before operator
 # E222 - multiple spaces after operator
+# E231 - missing whitespace after ','
 # E241 - multiple spaces after ‘,’
 # E265 - block comment should start with ‘# ‘
 # E271 - multiple spaces after keyword
@@ -37,6 +38,31 @@ ignore = D100,D101,D102,D103,D105,D200,D205,D210,D400,D401,D403,E127,E201,E202,E
 # N806 - variable in function should be lowercase
 # N* codes come from pep8-naming, which integrates with flake8
 # See also https://github.com/PyCQA/pep8-naming#error-codes
+
+# W503 - line break before binary operator
+#
+# The reason for adding W503 to the ignored list is because W503 (Line break
+# occurred before a binary operator) and W504 (Line break occurred after a binary
+# operator) are both enabled in flake8 by default for some reason.  But they are
+# mutually exclusive so one has to be disabled / ignored.
+#
+# According to pep8 at the time of the commit
+# https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
+#
+# ```
+# income = (gross_wages +
+#           taxable_interest +
+#           (dividends - qualified_dividends) -
+#           ira_deduction -
+#           student_loan_interest)
+# income = (gross_wages
+#           + taxable_interest
+#           + (dividends - qualified_dividends)
+#           - ira_deduction
+#           - student_loan_interest)
+# ```
+#
+# W504 (Line break occurred after a binary operator) is the correct behavior.
 
 # Exclude the git directory and virtualenv directory (as `.env`)
 exclude = .git,.env

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,1 @@
-
-add_subdirectory( cpp )
+add_subdirectory(cpp)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-#include_directories(${CMAKE_SOURCE_DIR}/include algorithms ext util nn .)
+# include_directories(${CMAKE_SOURCE_DIR}/include algorithms ext util nn .)
 
 message(STATUS "PYDARKNET_VERSION = ${PYDARKNET_VERSION}")
 set(PYDARKNET_VERSION ${PYDARKNET_VERSION})
@@ -10,8 +10,8 @@ add_definitions(-D_PYDARKNET_VERSION=${PYDARKNET_VERSION})
 add_definitions(-DPYDARKNET_VERSION_=${PYDARKNET_VERSION})
 add_definitions(-DPYDARKNET_VERSION=${PYDARKNET_VERSION})
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pydarknet/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/pydarknet/config.h)
-
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pydarknet/config.h.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/pydarknet/config.h)
 
 file(GLOB C_SOURCES "pydarknet/*.c")
 file(GLOB HEADER_SOURCES "pydarknet/*.h")
@@ -19,143 +19,141 @@ file(GLOB CU_SOURCES "pydarknet/*.cu")
 
 add_library(pydarknet_s STATIC "${C_SOURCES};${HEADER_SOURCES}")
 
-target_link_libraries(pydarknet_s
-    ${OpenCV_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT}
-)
+target_link_libraries(pydarknet_s ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-    set_target_properties(pydarknet_s PROPERTIES COMPILE_FLAGS -fPIC)
+  set_target_properties(pydarknet_s PROPERTIES COMPILE_FLAGS -fPIC)
 endif()
 
 set_property(TARGET pydarknet_s PROPERTY COMPILE_DEFINITIONS PYDARKNET_STATIC)
 
-if (BUILD_CUDA_LIB)
-    SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-DPYDARKNET_USE_CUDA")
-    # set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--gpu-architecture=compute_50;--gpu-code=compute_50;--compiler-options;${CFLAGS}")
-    # set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--gpu-architecture=compute_50;--gpu-code=compute_50;--compiler-options")
+if(BUILD_CUDA_LIB)
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-DPYDARKNET_USE_CUDA")
+  # set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--gpu-architecture=compute_50;--gpu-
+  # code=compute_50;--compiler-options;${CFLAGS}") set(CUDA_NVCC_FLAGS
+  # "${CUDA_NVCC_FLAGS};--gpu-architecture=compute_50;--gpu-
+  # code=compute_50;--compiler-options")
 
-    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler")
-        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-fPIC")
-        if (NVCC_COMPILER_BINDIR)
-            set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};--compiler-bindir=${NVCC_COMPILER_BINDIR}")
-        endif()
-    else()
-        set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};" )
+  if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-fPIC")
+    if(NVCC_COMPILER_BINDIR)
+      set(CUDA_NVCC_FLAGS
+          "${CUDA_NVCC_FLAGS};--compiler-bindir=${NVCC_COMPILER_BINDIR}")
     endif()
+  else()
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};")
+  endif()
 
-    cuda_add_library(pydarknet_cuda_s STATIC "${C_SOURCES};${HEADER_SOURCES};${CU_SOURCES}")
+  cuda_add_library(pydarknet_cuda_s STATIC
+                   "${C_SOURCES};${HEADER_SOURCES};${CU_SOURCES}")
 
-    target_link_libraries(pydarknet_cuda_s
-        ${OpenCV_LIBS}
-        ${CMAKE_THREAD_LIBS_INIT}
-        ${CUDA_LIBRARIES}
-        ${CUDA_CUBLAS_LIBRARIES}
-        ${CUDA_curand_LIBRARY}
-    )
+  target_link_libraries(
+    pydarknet_cuda_s ${OpenCV_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CUDA_LIBRARIES}
+    ${CUDA_CUBLAS_LIBRARIES} ${CUDA_curand_LIBRARY})
 
-    set_property(TARGET pydarknet_cuda_s PROPERTY COMPILE_DEFINITIONS PYDARKNET_STATIC)
-    if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
-        set_target_properties(pydarknet_cuda_s PROPERTIES COMPILE_FLAGS -fPIC)
-    endif()
+  set_property(TARGET pydarknet_cuda_s PROPERTY COMPILE_DEFINITIONS
+                                                PYDARKNET_STATIC)
+  if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_CLANG)
+    set_target_properties(pydarknet_cuda_s PROPERTIES COMPILE_FLAGS -fPIC)
+  endif()
 endif()
 
 add_library(pydarknet SHARED "${HEADER_SOURCES}")
 
-if (BUILD_CUDA_LIB)
-    cuda_add_library(pydarknet_cuda SHARED "${HEADER_SOURCES}")
-endif ()
+if(BUILD_CUDA_LIB)
+  cuda_add_library(pydarknet_cuda SHARED "${HEADER_SOURCES}")
+endif()
 
-if (OS_IS_LINUX)
-    set(LINK_FLAG_PREFIX "-Wl,--whole-archive")
-    set(LINK_FLAG_POSTFIX "-Wl,--no-whole-archive")
+if(OS_IS_LINUX)
+  set(LINK_FLAG_PREFIX "-Wl,--whole-archive")
+  set(LINK_FLAG_POSTFIX "-Wl,--no-whole-archive")
 
-    set_target_properties(pydarknet PROPERTIES LINKER_LANGUAGE CXX)
+  set_target_properties(pydarknet PROPERTIES LINKER_LANGUAGE CXX)
 
-    if (BUILD_CUDA_LIB)
-        set_target_properties(pydarknet_cuda PROPERTIES LINKER_LANGUAGE CXX)
-    endif ()
-elseif (OS_IS_MACOS)
-    set(LINK_FLAG_PREFIX "-Wl,-all_load")
+  if(BUILD_CUDA_LIB)
+    set_target_properties(pydarknet_cuda PROPERTIES LINKER_LANGUAGE CXX)
+  endif()
+elseif(OS_IS_MACOS)
+  set(LINK_FLAG_PREFIX "-Wl,-all_load")
 
-    set_target_properties(pydarknet PROPERTIES LINKER_LANGUAGE CXX)
+  set_target_properties(pydarknet PROPERTIES LINKER_LANGUAGE CXX)
 
-    if (BUILD_CUDA_LIB)
-        set_target_properties(pydarknet_cuda PROPERTIES LINKER_LANGUAGE CXX)
-    endif ()
-else ()
-    set(LINK_FLAG_PREFIX "/WHOLEARCHIVE")
+  if(BUILD_CUDA_LIB)
+    set_target_properties(pydarknet_cuda PROPERTIES LINKER_LANGUAGE CXX)
+  endif()
+else()
+  set(LINK_FLAG_PREFIX "/WHOLEARCHIVE")
 
-    set_target_properties(pydarknet PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
+  set_target_properties(pydarknet PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
 
-    if (BUILD_CUDA_LIB)
-        set_target_properties(pydarknet_cuda PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS YES)
-    endif ()
-endif ()
+  if(BUILD_CUDA_LIB)
+    set_target_properties(pydarknet_cuda PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS
+                                                    YES)
+  endif()
+endif()
 
-target_link_libraries(pydarknet ${LINK_FLAG_PREFIX} pydarknet_s ${LINK_FLAG_POSTFIX})
+target_link_libraries(pydarknet ${LINK_FLAG_PREFIX} pydarknet_s
+                      ${LINK_FLAG_POSTFIX})
 
-if (BUILD_CUDA_LIB)
-    target_link_libraries(pydarknet_cuda ${LINK_FLAG_PREFIX} pydarknet_cuda_s ${LINK_FLAG_POSTFIX})
-    #   target_link_libraries(pydarknet_cuda cudpp_x86_64)
-endif ()
+if(BUILD_CUDA_LIB)
+  target_link_libraries(pydarknet_cuda ${LINK_FLAG_PREFIX} pydarknet_cuda_s
+                        ${LINK_FLAG_POSTFIX})
+  # target_link_libraries(pydarknet_cuda cudpp_x86_64)
+endif()
 
-set_target_properties(pydarknet PROPERTIES
-    VERSION ${PYDARKNET_VERSION}
-    SOVERSION ${PYDARKNET_SOVERSION}
-    DEFINE_SYMBOL PYDARKNET_EXPORTS
-)
+set_target_properties(
+  pydarknet
+  PROPERTIES VERSION ${PYDARKNET_VERSION} SOVERSION ${PYDARKNET_SOVERSION}
+             DEFINE_SYMBOL PYDARKNET_EXPORTS)
 
-if (BUILD_CUDA_LIB)
-    set_target_properties(pydarknet_cuda PROPERTIES
-        VERSION ${PYDARKNET_VERSION}
-        SOVERSION ${PYDARKNET_SOVERSION}
-        DEFINE_SYMBOL PYDARKNET_EXPORTS
-    )
+if(BUILD_CUDA_LIB)
+  set_target_properties(
+    pydarknet_cuda
+    PROPERTIES VERSION ${PYDARKNET_VERSION} SOVERSION ${PYDARKNET_SOVERSION}
+               DEFINE_SYMBOL PYDARKNET_EXPORTS)
 endif()
 
 if(NOT SKBUILD)
-    install (
-        TARGETS pydarknet pydarknet_s
-        EXPORT ${targets_export_name}
-        INCLUDES DESTINATION include
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-        ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-    )
+  install(
+    TARGETS pydarknet pydarknet_s
+    EXPORT ${targets_export_name}
+    INCLUDES
+    DESTINATION include
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR})
 
-    if (BUILD_CUDA_LIB)
-        install (
-            TARGETS pydarknet_cuda pydarknet_cuda_s
-            EXPORT ${targets_export_name}
-            INCLUDES DESTINATION include
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-            ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-        )
-    endif()
+  if(BUILD_CUDA_LIB)
+    install(
+      TARGETS pydarknet_cuda pydarknet_cuda_s
+      EXPORT ${targets_export_name}
+      INCLUDES
+      DESTINATION include
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
+      ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR})
+  endif()
 
-    install (
-        DIRECTORY pydarknet
-        DESTINATION include
-        FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
-    )
+  install(
+    DIRECTORY pydarknet
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")
 
 else()
-    install (
-        TARGETS pydarknet pydarknet_s
-        EXPORT ${targets_export_name}
-        LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-        ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-    )
+  install(
+    TARGETS pydarknet pydarknet_s
+    EXPORT ${targets_export_name}
+    LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
+    ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR})
 
-    if (BUILD_CUDA_LIB)
-        install (
-            TARGETS pydarknet_cuda pydarknet_cuda_s
-            EXPORT ${targets_export_name}
-            LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-            ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
-        )
-    endif()
+  if(BUILD_CUDA_LIB)
+    install(
+      TARGETS pydarknet_cuda pydarknet_cuda_s
+      EXPORT ${targets_export_name}
+      LIBRARY DESTINATION ${PYDARKNET_LIB_INSTALL_DIR}
+      ARCHIVE DESTINATION ${PYDARKNET_LIB_INSTALL_DIR})
+  endif()
 endif()


### PR DESCRIPTION
- Add W503 to ignored flake8 warnings in setup.cfg

   The reason for adding W503 to the ignored list is because W503 (Line
  break occurred before a binary operator) and W504 (Line break occurred
  after a binary operator) are both enabled in flake8 by default for some
  reason.  But they are mutually exclusive so one has to be disabled /
  ignored.

- Add brunette pre-commit hook for codestyle correction

   
- Run brunette on all files

   
- Add cmake format pre-commit hook

   
- Run cmake format pre-commit hook

