### PR TITLE
Replace utool with wbia-utool in runtime requirements

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,3 @@
 numpy
 opencv-python >= 4.2.0
-utool
-# wbia-utool
+wbia-utool


### PR DESCRIPTION
We need to use our version of utool which is called `wbia-utool` because
we are installing `wbia-utool` everywhere else and it causes the `utool`
code to be overwritten.